### PR TITLE
Fix typo in lab results route comment

### DIFF
--- a/backend/app/routes/lab_results.py
+++ b/backend/app/routes/lab_results.py
@@ -28,7 +28,7 @@ router = APIRouter()
 
 @router.get(
     "/lab_set/{fhir_id}"
-)  # this reffers to the patient's FHIR ID not the lab set id
+)  # this refers to the patient's FHIR ID not the lab set id
 async def get_all_patient_lab_sets(
     fhir_id: str,
     include_observations: bool = False,


### PR DESCRIPTION
## Summary
- correct comment typo in `lab_results.py`

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6840ada610cc832a9bdad21465c3d797